### PR TITLE
[COGB-26] Faltou finalizar a integração dos novos models com o Postgr…

### DIFF
--- a/src/models/Field.js
+++ b/src/models/Field.js
@@ -1,13 +1,13 @@
 /**
  * Field class represents a field in a database model.
- * It initializes with a key, type, and optional properties like allowNull, unique, defaultValue, and autoIncrement.
+ * It initializes with a key, type, and optional properties like notNull, unique, defaultValue, and autoIncrement.
  *
  * @class Field
  * @param {Object} setup - The setup object for the field.
  * @param {string} setup.name - The name of the field.
  * @param {string} setup.type - The data type of the field.
  * @param {*} [setup.defaultValue=null] - The default value for the field.
- * @param {boolean} [setup.allowNull=true] - Whether the field can be null.
+ * @param {boolean} [setup.notNull=true] - Whether the field can be null.
  * @param {boolean} [setup.unique=false] - Whether the field must be unique.
  * @param {boolean} [setup.primaryKey=false] - Whether the field is a primary key.
  * @param {boolean} [setup.autoIncrement=false] - Whether the field is auto-incrementing.
@@ -18,28 +18,64 @@ class Field {
       const {
          name,
          type,
-         allowNull,
+         notNull,
          unique,
          primaryKey,
          autoIncrement,
-         defaultValue = null,
+         defaultValue,
       } = setup;
 
       if (!name || typeof name !== 'string') {
          throw new Error('Field name is required');
       }
 
-      if (!type || typeof type !== 'string') {
-         throw new Error('Field type is required');
-      }
-
       this.name = name;
       this.type = type;
       this.defaultValue = defaultValue;
-      this.allowNull = Boolean(allowNull);
+      this.notNull = Boolean(notNull);
       this.unique = Boolean(unique);
       this.primaryKey = Boolean(primaryKey);
       this.autoIncrement = Boolean(autoIncrement);
+   }
+
+   buildDefinitionSQL() {
+      const constraints = [];
+
+      if (this.type) {
+         constraints.push(this.type);
+      }
+
+      if (this.primaryKey) {
+         constraints.push('SERIAL PRIMARY KEY');
+      }
+
+      if (this.unique) {
+         constraints.push('UNIQUE');
+      }
+
+      if (this.autoIncrement) {
+         constraints.push('AUTOINCREMENT');
+      }
+
+      if (this.notNull) {
+         constraints.push('NOT NULL');
+      }
+
+      if (this.defaultValue !== undefined && this.defaultValue !== null) {
+         if (this.defaultValue === 'CURRENT_TIMESTAMP') {
+            constraints.push('DEFAULT CURRENT_TIMESTAMP');
+         }
+         
+         else if (typeof this.defaultValue === 'string') {
+            constraints.push(`DEFAULT '${this.defaultValue}'`);
+         }
+         
+         else {
+            constraints.push(`DEFAULT ${this.defaultValue}`);
+         }
+      }
+
+      return `${this.name} ${constraints.join(' ')}`;
    }
 }
 

--- a/src/models/Schema.js
+++ b/src/models/Schema.js
@@ -20,6 +20,14 @@ class Schema {
       this.name = name;
       this.tables = tables.map(table => new Table(table));
    }
+
+   buildCreateSchemaQuery() {
+      if (!this.name) {
+         throw new Error('Schema name is required to build the "create schema" query');
+      }
+
+      return `CREATE SCHEMA IF NOT EXISTS ${this.name};`;
+   }
 }
 
 module.exports = Schema;

--- a/src/models/Table.js
+++ b/src/models/Table.js
@@ -20,6 +20,15 @@ class Table {
       this.name = name;
       this.fields = fields.map(field => new Field(field));
    }
+
+   buildCreateTableQuery(schemaName) {
+      if (!schemaName || !this.name) {
+         throw new Error('Table name and schema name is required to build the "create table" query');
+      }
+
+      const fieldsDefinition = this.fields.map(field => field.buildDefinitionSQL()).join(', ');
+      return `CREATE TABLE IF NOT EXISTS ${schemaName}.${this.name} (${fieldsDefinition});`;
+   }
 }
 
 module.exports = Table;

--- a/src/schemas/tables/products.js
+++ b/src/schemas/tables/products.js
@@ -3,13 +3,13 @@ const Table = require("../../models/Table");
 const products = new Table({
    name: 'products',
    fields: [
-      { name: 'id', type: 'INTEGER', primaryKey: true, autoIncrement: true },
+      { name: 'id', primaryKey: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'name', type: 'VARCHAR(255)', notNull: true },
       { name: 'description', type: 'TEXT' },
       { name: 'price', type: 'DECIMAL(10, 2)', notNull: true },
-      { name: 'stock_quantity', type: 'INTEGER', notNull: true, defaultValue: 0 },
-      { name: 'category_id', type: 'INTEGER', notNull: true }
+      { name: 'stock_quantity', type: 'INTEGER', defaultValue: 0 },
+      { name: 'category_name', type: 'VARCHAR(255)', defaultValue: 'General' },
    ]
 });
 

--- a/src/schemas/tables/users.js
+++ b/src/schemas/tables/users.js
@@ -3,11 +3,11 @@ const Table = require("../../models/Table");
 const users = new Table({
    name: 'users',
    fields: [
-      { name: 'id', type: 'INTEGER', primaryKey: true, autoIncrement: true },
-      { name: 'firstname', type: 'VARCHAR(255)', notNull: true },
-      { name: 'lastname', type: 'VARCHAR(255)', notNull: true },
-      { name: 'email', type: 'VARCHAR(255)', unique: true, notNull: true },
-      { name: 'password', type: 'VARCHAR(255)', notNull: true },
+      { name: 'id', primaryKey: true },
+      { name: 'firstname', type: 'VARCHAR(255)' },
+      { name: 'lastname', type: 'VARCHAR(255)' },
+      { name: 'email', type: 'VARCHAR(255)', unique: true },
+      { name: 'password', type: 'VARCHAR(255)' },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' }
    ]
 });


### PR DESCRIPTION
## [COGB-26] Descrição

Esta pull request traz melhorias significativas no processo de criação de schemas e tabelas do banco de dados, além de pequenos refatoramentos nas definições de campos. As mudanças incluem a adição de métodos de geração de SQL nas classes `Field`, `Table` e `Schema`, simplificação do serviço `PostgresDB` e atualização das definições de schema para as tabelas `products` e `users`.

### Melhorias na criação de schemas e tabelas:
* Adicionado o método `buildCreateSchemaQuery` à classe `Schema` para gerar SQL de criação de schema. (`src/models/Schema.js`)
* Adicionado o método `buildCreateTableQuery` à classe `Table` para gerar SQL de criação de tabela, incluindo constraints de campos. (`src/models/Table.js`)
* Adicionado o método `buildDefinitionSQL` à classe `Field` para gerar SQL para definição individual de campos, suportando constraints como `NOT NULL`, `UNIQUE` e `DEFAULT`. (`src/models/Field.js`)

### Refatoração no serviço `PostgresDB`:
* Substituída a geração de SQL inline por chamadas aos novos métodos `buildCreateSchemaQuery` e `buildCreateTableQuery`, simplificando a lógica de criação de schemas e tabelas. (`src/services/DataBase/PostgresDB.js`)
* Melhorado o tratamento de erros no método `createTable`, incluindo detalhes específicos da tabela nas mensagens de erro. (`src/services/DataBase/PostgresDB.js`)

### Atualizações nas definições de schemas:
* Atualizado o schema da tabela `products` para usar a nova propriedade `notNull` e adicionado valor padrão para o campo `category_name`. (`src/schemas/tables/products.js`)
* Atualizado o schema da tabela `users` para remover constraints `notNull` de alguns campos, proporcionando maior flexibilidade. (`src/schemas/tables/users.js`)

### Pequenas mudanças nas definições de campos:
* Substituída a propriedade `allowNull` por `notNull` para

[COGB-26]: https://feliperamosdev.atlassian.net/browse/COGB-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ