### PR TITLE
[COGB-53] Criar classe construtora GetQuerySQL

### DIFF
--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -12,7 +12,7 @@ module.exports = async function(req, res) {
    
       res.status(200).send({
          success: true,
-         products: products.data || []
+         products: products || []
       });
    } catch (error) {
       res.status(500).send(api.toError('Internal server error'));

--- a/src/services/DataBase/PostgresDB.js
+++ b/src/services/DataBase/PostgresDB.js
@@ -1,6 +1,6 @@
 const { Pool } = require('pg');
 const DataBase = require('./DataBase');
-const QuerySQL = require('./builders/QuerySQL');
+const GetQuerySQL = require('./builders/GetQuerySQL');
 
 class PostgresDB extends DataBase {
    /**
@@ -276,7 +276,7 @@ class PostgresDB extends DataBase {
    }
 
    query(schemaName, tableName) {
-      return new QuerySQL(this, schemaName, tableName);
+      return new GetQuerySQL(this, schemaName, tableName);
    }
 
    /**

--- a/src/services/DataBase/builders/GetQuerySQL.js
+++ b/src/services/DataBase/builders/GetQuerySQL.js
@@ -1,0 +1,59 @@
+const QuerySQL = require('./QuerySQL');
+
+class GetQuerySQL extends QuerySQL {
+   constructor(database, schemaName, tableName) {
+      super(database, schemaName, tableName);
+
+      this.selectClause = 'SELECT * FROM';
+      this.sortClause = '';
+   }
+
+   toString() {
+      const queryParts = [
+         this.selectClause,
+         this.tablePath,
+         this.whereClause,
+         this.sortClause,
+         this.limitClause
+      ];
+
+      return queryParts.filter(Boolean).join(' ');
+   }
+
+   select(fields = ['*']) {
+      if (Array.isArray(fields) && fields.length) {
+         const validatedFields = fields.map(field => this.charsVerifier(field));  
+         this.selectClause = `SELECT ${validatedFields.join(', ')} FROM`;
+      } else {
+         this.selectClause = 'SELECT * FROM';
+      }
+
+      return this;
+   }
+
+   sort(sort = {}) {
+      const allowedOrders = ['ASC', 'DESC'];
+      if (typeof sort !== 'object' || Object.keys(sort).length === 0) {
+         return this;
+      }
+
+      const sortEntries = Object.entries(sort);
+      const parsed = sortEntries.map(([key, order]) => {
+         const table = this.database.getTable(this.tablePath);
+         const field = table && table.getField(key);
+
+         if (!field || !allowedOrders.includes(order.toUpperCase())) {
+            return;
+         }
+
+         return `${key} ${order.toUpperCase()}`;
+      }).filter(Boolean);
+
+      if (parsed.length) {
+         this.sortClause = `ORDER BY ${parsed.join(', ')}`;
+      }
+      return this;
+   }
+}
+
+module.exports = GetQuerySQL;

--- a/src/services/DataBase/builders/QuerySQL.js
+++ b/src/services/DataBase/builders/QuerySQL.js
@@ -8,9 +8,7 @@ class QuerySQL {
       this.schemaName = schemaName;
       this.tableName = tableName;
 
-      this.selectClause = 'SELECT * FROM';
       this.whereClause = '';
-      this.sortClause = '';
       this.limitClause = '';
       this.values = [];
    }
@@ -23,35 +21,12 @@ class QuerySQL {
       return `${this.charsVerifier(this.schemaName)}.${this.charsVerifier(this.tableName)}`;
    }
 
-   toString() {
-      const queryParts = [
-         this.selectClause,
-         this.tablePath,
-         this.whereClause,
-         this.sortClause,
-         this.limitClause
-      ];
-
-      return queryParts.filter(Boolean).join(' ');
-   }
-
    charsVerifier(identifier) {
       if (!/^[a-zA-Z0-9_]+$/.test(identifier)) {
          throw new Error(`Invalid identifier: ${identifier}`);
       }
 
       return identifier;
-   }
-
-   select(fields = ['*']) {
-      if (Array.isArray(fields) && fields.length) {
-         const validatedFields = fields.map(field => this.charsVerifier(field));  
-         this.selectClause = `SELECT ${validatedFields.join(', ')} FROM`;
-      } else {
-         this.selectClause = 'SELECT * FROM';
-      }
-
-      return this;
    }
 
    from(schemaName, tableName) {
@@ -128,30 +103,6 @@ class QuerySQL {
          this.whereClause = '';
       }
 
-      return this;
-   }
-
-   sort(sort = {}) {
-      const allowedOrders = ['ASC', 'DESC'];
-      if (typeof sort !== 'object' || Object.keys(sort).length === 0) {
-         return this;
-      }
-
-      const sortEntries = Object.entries(sort);
-      const parsed = sortEntries.map(([key, order]) => {
-         const table = this.database.getTable(this.tablePath);
-         const field = table && table.getField(key);
-
-         if (!field || !allowedOrders.includes(order.toUpperCase())) {
-            return;
-         }
-
-         return `${key} ${order.toUpperCase()}`;
-      }).filter(Boolean);
-
-      if (parsed.length) {
-         this.sortClause = `ORDER BY ${parsed.join(', ')}`;
-      }
       return this;
    }
 


### PR DESCRIPTION
## [COGB-53] Descrição
Criei a classe construtora de query get que estende a QuerySQL padrão

This pull request refactors the database query builder by introducing a new `GetQuerySQL` class to handle specific query operations, simplifying the `QuerySQL` class, and updating references across the codebase. Additionally, it includes a minor fix in the API response structure.

### Refactoring of Query Builder:

* [`src/services/DataBase/builders/GetQuerySQL.js`](diffhunk://#diff-912ef4e124d753ef7d8060d6283aebf8854adbcd43c135f7dc63c4bee119e8f7R1-R59): Introduced the `GetQuerySQL` class, extending `QuerySQL` to handle `SELECT` and `ORDER BY` clauses. This class includes methods for selecting fields (`select`) and sorting results (`sort`) with validation.
* [`src/services/DataBase/builders/QuerySQL.js`](diffhunk://#diff-2cd151f6fa4b71951dd5617e348c0d1df02ddc99314ab77f721ab1999a454d1bL11-L13): Removed `select`, `sort`, and `toString` methods, as well as related properties (`selectClause`, `sortClause`) from the `QuerySQL` class. These functionalities are now handled in the `GetQuerySQL` class. [[1]](diffhunk://#diff-2cd151f6fa4b71951dd5617e348c0d1df02ddc99314ab77f721ab1999a454d1bL11-L13) [[2]](diffhunk://#diff-2cd151f6fa4b71951dd5617e348c0d1df02ddc99314ab77f721ab1999a454d1bL26-L37) [[3]](diffhunk://#diff-2cd151f6fa4b71951dd5617e348c0d1df02ddc99314ab77f721ab1999a454d1bL46-L56) [[4]](diffhunk://#diff-2cd151f6fa4b71951dd5617e348c0d1df02ddc99314ab77f721ab1999a454d1bL134-L157)

### Integration of `GetQuerySQL`:

* [`src/services/DataBase/PostgresDB.js`](diffhunk://#diff-9810b7bc14619fb2f922e1373af6a26e9c77e24f562449e6f7f5780911ca4603L3-R3): Updated the `query` method to return an instance of `GetQuerySQL` instead of `QuerySQL`. Adjusted the import statement to use `GetQuerySQL`. [[1]](diffhunk://#diff-9810b7bc14619fb2f922e1373af6a26e9c77e24f562449e6f7f5780911ca4603L3-R3) [[2]](diffhunk://#diff-9810b7bc14619fb2f922e1373af6a26e9c77e24f562449e6f7f5780911ca4603L279-R279)

### Minor Fix:

* [`src/controllers/index.controller.js`](diffhunk://#diff-8332fe4afa08f00649bec07b9354a7e9cb0c1f85fdfbdc7a49a68813a4262b62L15-R15): Fixed the API response to directly use `products` instead of `products.data`, ensuring compatibility with the updated data structure.

[COGB-53]: https://feliperamosdev.atlassian.net/browse/COGB-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ