### PR TITLE
[COGB-56] Criar classe construtora DeleteQuerySQL

### DIFF
--- a/src/services/DataBase/builders/DeleteQuerySQL.js
+++ b/src/services/DataBase/builders/DeleteQuerySQL.js
@@ -1,0 +1,27 @@
+const QuerySQL = require('./QuerySQL');
+
+class DeleteQuerySQL extends QuerySQL {
+   constructor(database, schemaName, tableName) {
+      super(database, schemaName, tableName);
+
+      this.isAllowedNullWhere = false;
+   }
+
+   get deleteClause() {
+      return `DELETE FROM ${this.tablePath}`;
+   }
+
+   toString() {
+      if (!this.whereClause && !this.isAllowedNullWhere) {
+         throw this.database.toError('Where clause is required for delete queries unless allowNullWhere is set.');
+      }
+
+      return [
+         this.deleteClause,
+         this.whereClause,
+         this.returningClause
+      ].filter(Boolean).join(' ');
+   }
+}
+
+module.exports = DeleteQuerySQL;


### PR DESCRIPTION
## [COGB-56] Descrição
Criei a construtora do Delete SQL

This pull request introduces a new class, `DeleteQuerySQL`, to handle SQL DELETE queries in a structured and reusable way. The class extends the existing `QuerySQL` class and adds functionality specific to DELETE operations.

### Key Changes:

#### New Class for DELETE Queries:
* **`DeleteQuerySQL` class**: Added a new class in `src/services/DataBase/builders/DeleteQuerySQL.js` that extends `QuerySQL` to handle DELETE SQL queries. It includes methods for generating the DELETE clause, validating the presence of a `WHERE` clause (unless explicitly allowed), and converting the query to a string.

[COGB-56]: https://feliperamosdev.atlassian.net/browse/COGB-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ