### PR TITLE
[COGB-52] Ajustar testes após as mudanças

### DIFF
--- a/src/__test__/services/DataBase/DataBase.test.js
+++ b/src/__test__/services/DataBase/DataBase.test.js
@@ -26,10 +26,6 @@ describe('DataBase Class', () => {
       await expect(db.createSchema()).rejects.toThrow('Method createSchema is implemented in PostgresDB or MongoDB');
    });
 
-   it('should throw error for insert()', async () => {
-      await expect(db.insert()).rejects.toThrow('Method insert is implemented in PostgresDB or MongoDB');
-   });
-
    it('should throw error for read()', async () => {
       await expect(db.select()).rejects.toThrow('Method read is implemented in PostgresDB or MongoDB');
    });

--- a/src/services/DataBase/DataBase.js
+++ b/src/services/DataBase/DataBase.js
@@ -71,7 +71,7 @@ class DataBase {
       throw new Error('Method create is implemented in PostgresDB or MongoDB');
    }
 
-   async query() {
+   async select() {
       throw new Error('Method read is implemented in PostgresDB or MongoDB');
    }
 

--- a/src/services/DataBase/builders/SQL.js
+++ b/src/services/DataBase/builders/SQL.js
@@ -138,14 +138,21 @@ class QuerySQL {
       try {
          const response = await this.database.pool.query(this.toString(), this.values);
 
+         if (!response || !response.rows) {
+            return this.database.toError('No data returned from the database.');
+         }
+
          return {
             success: true,
             data: response.rows || [],
             count: response.rowCount || 0
          }
       } catch (error) {
-         const errorData = this.database.toError('Error reading records from database: ' + error.message);
-         return errorData;
+         if (error.code === '22P02') { // Invalid text representation
+            error.code = 400; // Bad Request
+         }
+      
+         return this.database.toError(error);
       }
    }
 }

--- a/src/services/DataBase/builders/SQL.js
+++ b/src/services/DataBase/builders/SQL.js
@@ -148,11 +148,12 @@ class QuerySQL {
             count: response.rowCount || 0
          }
       } catch (error) {
-         if (error.code === '22P02') { // Invalid text representation
-            error.code = 400; // Bad Request
+         let mappedError = error;
+         if (error.code === '22P02') {
+            mappedError = { ...error, code: 400 }; 
          }
       
-         return this.database.toError(error);
+         return this.database.toError(mappedError);
       }
    }
 }


### PR DESCRIPTION
## [COGB-52] Descrição
Ajustei os testes Jest para a atual abordagem de banco de dados

This pull request refactors database-related methods and tests to improve consistency, error handling, and code clarity. The changes include renaming methods for better readability, enhancing error handling for database operations, and updating test cases to reflect the new method names and behaviors.

### Method Renaming and Refactoring:
* Renamed `query` method to `select` in the `DataBase` class to better reflect its purpose. (`src/services/DataBase/DataBase.js`, [src/services/DataBase/DataBase.jsL74-R74](diffhunk://#diff-be8a9897d070d5608b9befdd4d43c958c18756ffd3ecd0baa0cc39220b79c4c0L74-R74))
* Updated method calls in `PostgresDB` tests to use the renamed `select` method and adjusted other method signatures to include schema parameters for consistency. (`src/__test__/services/DataBase/PostgresDB.test.js`, [src/__test__/services/DataBase/PostgresDB.test.jsL44-R110](diffhunk://#diff-d6f31f7681d536d4674cea292dd6a586c2b2c9c1364dff6cd81fdebeecee4148L44-R110))

### Improved Error Handling:
* Enhanced error handling in the `QuerySQL` class to return meaningful error messages when no data is returned or when invalid input is provided (e.g., invalid text representation). (`src/services/DataBase/builders/SQL.js`, [src/services/DataBase/builders/SQL.jsR141-R155](diffhunk://#diff-e12ccff8ea09c3f9b96d29a2fa3d8bfa5dd09fcbc31d6d7203050a937e37ac43R141-R155))
* Updated `delete` method in `PostgresDB` tests to enforce a `where` clause and return appropriate error messages when missing. (`src/__test__/services/DataBase/PostgresDB.test.js`, [src/__test__/services/DataBase/PostgresDB.test.jsL44-R110](diffhunk://#diff-d6f31f7681d536d4674cea292dd6a586c2b2c9c1364dff6cd81fdebeecee4148L44-R110))

### Test Suite Updates:
* Removed redundant test cases for deprecated methods (`buildWhere`, `buildSet`, `getConditionValues`) in `PostgresDB` tests. (`src/__test__/services/DataBase/PostgresDB.test.js`, [src/__test__/services/DataBase/PostgresDB.test.jsL44-R110](diffhunk://#diff-d6f31f7681d536d4674cea292dd6a586c2b2c9c1364dff6cd81fdebeecee4148L44-R110))
* Adjusted test cases in the `DataBase` and `PostgresDB` test suites to align with the renamed and refactored methods. (`src/__test__/services/DataBase/DataBase.test.js`, [[1]](diffhunk://#diff-01e73efa83735247e1df6a9d02f543e6041a30370dd9cf8e17c28bd075cbf129L29-L32); `src/__test__/services/DataBase/PostgresDB.test.js`, [[2]](diffhunk://#diff-d6f31f7681d536d4674cea292dd6a586c2b2c9c1364dff6cd81fdebeecee4148L26-R26)

[COGB-52]: https://feliperamosdev.atlassian.net/browse/COGB-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ